### PR TITLE
Resolve #1: Use the public URL for the ThunderRequest submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ThunderRequest"]
 	path = ThunderRequest
-	url = git@github.com:3sidedcube/iOS-ThunderRequest.git
+	url = git://github.com/3sidedcube/iOS-ThunderRequest.git


### PR DESCRIPTION
This allows people who don't have a GitHub SSH key set up to pull the submodule.
